### PR TITLE
Remove echo-cancellation to fix self-cancelling of voice

### DIFF
--- a/src/js/script.es
+++ b/src/js/script.es
@@ -142,6 +142,7 @@ function getConstraints() {
     if (audioId !== null) {
         constraints.audio = {
             deviceId: audioId,
+            echoCancellation: false,
         };
     }
     if (videoId !== null && videoId !== "") {


### PR DESCRIPTION
@shimataro また、ご確認をお願いします！ :pray: 

**日本語**
- 自分から自分へのコールをしているので、「あぁぁ」みたいに同じ音をずっと言ったら、エコキャンセリングが起こってしまって声が聞こえにくくなってしまう現象がありました。
- それを解決するには、`getUserMedia`のconstraintsに、あえて`echoCancellation`を`false`にしました。
（その影響で、バックグラウンドノイズが前よりちょっとだけ大きく聞こえることになりますけども、そんなに気づくレベルではないので問題ないと思います。）  

**英語**
- As the call you make is from yourself to yourself, if you make a constant sound (i.e. "ahhh"), the sound itself gets repressed by echo-cancellation, making it sometimes difficult to hear your own voice.
- Making the `echoCancellation` audio constraint `false` inside `getUserMedia` solved the issue.
(As a result, you're able to hear slightly more background noise than before, though it's at a barely noticeable level, so there should be no issue.)
